### PR TITLE
feat: delete sample repository and add aip

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -68,19 +68,15 @@ repositories:
     url: https://github.com/tier4/velodyne_vls.git
     version: 55dffdf3b3ef889e149977dc6ab1da124b5176c9
   # sensor_kit
-  sensor_kit/sample_sensor_kit_launch:
+  sensor_kit/aip_launcher:
     type: git
-    url: https://github.com/autowarefoundation/sample_sensor_kit_launch.git
-    version: 06330e6b07449a3609ced295c0a9ce6a1805ef99
+    url: https://github.com/tier4/aip_launcher.git
+    version: tier4/universe
   sensor_kit/external/awsim_sensor_kit_launch: # TODO: Integrate into sample_sensor_kit_launch
     type: git
     url: https://github.com/RobotecAI/awsim_sensor_kit_launch.git
     version: a1f5993407ffeb4abcf97a49cd1b4034768d97b4
   # vehicle
-  vehicle/sample_vehicle_launch:
-    type: git
-    url: https://github.com/autowarefoundation/sample_vehicle_launch.git
-    version: 157238ca77de7b0a59f71a0b28f456741fab3ca2
   vehicle/external/pacmod_interface:
     type: git
     url: https://github.com/tier4/pacmod_interface.git
@@ -88,10 +84,10 @@ repositories:
   # param
   param/autoware_individual_params:
     type: git
-    url: https://github.com/autowarefoundation/autoware_individual_params.git
-    version: 09082b6cbb99a840c53878a190616d35a40b569f
+    url: https://github.com/tier4/autoware_individual_params.git
+    version: main
   # golfcart
   vehicle/golfcart_description:
     type: git
     url: https://github.com/tier4/golfcart_description.git
-    version: main   
+    version: main


### PR DESCRIPTION
## Description
Support for using aip instead of sample vehicle.

Delete from autoware.repos
- autowarefoundation/sample_sensor_kit_launch
- autowarefoundation/sample_vehicle_launch
- autowarefoundation/autoware_individual_params

Add to autoware.repos
- tier4/aip_launcher
- tier4/autoware_individual_params

<!-- Write a brief description of this PR. -->

## Tests Performed

Launch planning simulator
```
ros2 launch autoware_launch planning_simulator.launch.xml map_path:={map_dir} vehicle_model:=golfcart sensor_model:=aip_x1
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
