### PR TITLE
fix(autoware.repos): bump autoware_auto_msgs to include the missing IDL includes

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -19,7 +19,7 @@ repositories:
   core/external/autoware_auto_msgs: # TODO(mfc): Remove when autoware_msgs is merged
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
-    version: f6642370c6f4f42a5dc0b6c1fc4a21396d4dc34c
+    version: 1e8b6d234e2690c9da386f006bb60835cdccddfd
   # universe
   universe/autoware.universe:
     type: git


### PR DESCRIPTION
## 概要

`autoware.repos` の `core/external/autoware_auto_msgs` のピンを、Foxglove のスキーマエラーを直す修正を含む**最小のコミット**まで上げる。

```diff
   core/external/autoware_auto_msgs: # TODO(mfc): Remove when autoware_msgs is merged
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
-    version: f6642370c6f4f42a5dc0b6c1fc4a21396d4dc34c
+    version: 1e8b6d234e2690c9da386f006bb60835cdccddfd
```

## 背景

foxglove_bridge を繋ぐと `Definition of ros2 schema x has changed during the server's runtime` が出て、`autoware_auto_perception_msgs/msg/DetectedObjects` などが Studio 側で読めなくなる。

原因は autoware_auto_msgs の IDL が、使っている型の `#include` を欠いていたこと。foxglove/ros-foxglove-bridge#253 で切り分けられていて、メンテナも「その版に tier4/autoware_auto_msgs#45 が入っているか確認してほしい」と回答している。

修正 tier4/autoware_auto_msgs#45（2023-09-01 マージ）が追加したのは `#include` 3 行だけ。

| ファイル | 追加された include |
| --- | --- |
| `autoware_auto_perception_msgs/msg/DetectedObjectKinematics.idl` | `geometry_msgs/msg/PoseWithCovariance.idl` |
| `autoware_auto_perception_msgs/msg/TrackedObjectKinematics.idl` | `geometry_msgs/msg/PoseWithCovariance.idl` |
| `autoware_auto_planning_msgs/msg/TrajectoryPoint.idl` | `geometry_msgs/msg/Pose.idl` |

現在のピン `f6642370` は 2023-01-30 で、この修正より前。

## なぜ 1e8b6d23 なのか（最新にしない理由）

`tier4/main` の履歴は線形で、現在のピン以降は次の 3 コミットしかない。

| コミット | 日付 | 内容 |
| --- | --- | --- |
| `e1795354` | 2023-05-08 | add UP_LEFT_ARROW and UP_RIGHT_ARROW for traffic_light (#42) |
| `1e8b6d23` | 2023-09-01 | **add missing includes for Pose / PoseWithCovariance (#45)** ← 目的の修正 |
| `624aae9f` | 2024-07-02 | docs(TrajectoryPoint): acceleration_mps2 のコメント追加 (#47) |

`1e8b6d23` が #45 を含む最小のコミットなので、ここで止めている。最新の `624aae9f` はコメント追加だけで実利が無いため入れていない。

## 注意点：#42 が TrafficLight の定数値を振り直している

`1e8b6d23` に上げると `e1795354`（#42）も一緒に入る。これは飛ばせない（線形履歴のため）。#42 は `UP_LEFT_ARROW` / `UP_RIGHT_ARROW` を**列挙の途中に挿入**しているので、以降の定数値がずれる。

| 定数 | 変更前 | 変更後 |
| --- | --- | --- |
| `UP_LEFT_ARROW` | （無し） | 9 |
| `UP_RIGHT_ARROW` | （無し） | 10 |
| `DOWN_ARROW` | 9 | 11 |
| `DOWN_LEFT_ARROW` | 10 | 12 |
| `DOWN_RIGHT_ARROW` | 11 | 13 |
| `CROSS` | 12 | 14 |
| `SOLID_OFF` | 13 | 15 |
| `SOLID_ON` | 14 | 16 |
| `FLASHING` | 15 | 17 |
| `UNKNOWN` | 16 | 18 |

### ワークスペース内は影響なしと確認した

`AutomotiveAIChallenge/autoware.universe` の `awsim-stable` を clone して確認した。

- `TrafficLight::` の定数を参照しているのは以下の 11 ファイルで、**すべて記号名での参照**。数値べた書きは無い
  - `common/tier4_traffic_light_rviz_plugin`, `perception/crosswalk_traffic_light_estimator`, `perception/traffic_light_classifier`（3ファイル）, `perception/traffic_light_visualization`（2ファイル）, `planning/behavior_velocity_planner`（crosswalk / intersection / traffic_light）
  - 例：`traffic_light_classifier` の `state2label_` も定数をキーにした対応表で、値がずれても整合する
- yaml / param / python / xml 側に `SOLID_ON` などの数値対応表を持つ箇所は無い
- 新定数 `UP_LEFT_ARROW` / `UP_RIGHT_ARROW` を参照している箇所は universe 側に存在しない（＝ビルドが壊れる要素も、挙動が変わる分岐も増えない）

ワークスペースは全体を同じ msgs でビルドし直すので、番号の振り直しは内部的に一貫する。

### 残るリスク

**このワークスペースの外で作られた数値**とは整合しなくなる。具体的には次の 2 つで、こちらでは検証できていない。

1. **AWSIM** — 信号情報を publish している場合、Unity 側にビルド済みの数値と食い違う可能性がある
2. **バンプ前に録った rosbag / mcap** — 信号トピックを含むものは、再生時に色・形状の意味がずれる

レースのシナリオで信号を使っていないなら、いずれも実害は無いはず。使っている場合はマージ前に確認してほしい。

## 代替案（採用しなかった）

#42 をどうしても避けたい場合は、org 側に `autoware_auto_msgs` を fork して `f6642370` の上に #45 だけ cherry-pick し、`autoware.repos` の url をその fork に向ける方法がある。ただし維持対象の fork が 1 つ増えるうえ、上で見たとおり #42 のワークスペース内への影響が無いので、単純なバンプを選んだ。必要ならこちらに切り替える。

## 確認したこと

- 変更は `autoware.repos` の 1 行のみ
- `1e8b6d234e2690c9da386f006bb60835cdccddfd` が `tier4/main` 上に存在し、#45 のマージコミットであることを API で確認済み
- **ビルドと実機/AWSIM での動作確認は未実施**。`vcs import` からの再ビルドが必要